### PR TITLE
feat: Add language switching feature with TopNav combobox

### DIFF
--- a/specs/002-language-switcher/checklists/requirements.md
+++ b/specs/002-language-switcher/checklists/requirements.md
@@ -1,0 +1,61 @@
+# Specification Quality Checklist: Language Switching Feature
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-04
+**Feature**: [Link to spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+  - **Status**: PASS - Spec focuses on user behavior, no code structures or frameworks mentioned
+- [x] Focused on user value and business needs
+  - **Status**: PASS - User stories describe what users can accomplish
+- [x] Written for non-technical stakeholders
+  - **Status**: PASS - Plain language used throughout, no technical jargon
+- [x] All mandatory sections completed
+  - **Status**: PASS - All sections present and filled with content
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+  - **Status**: PASS - No markers found in the specification
+- [x] Requirements are testable and unambiguous
+  - **Status**: PASS - All FRs can be verified through user actions
+- [x] Success criteria are measurable
+  - **Status**: PASS - Specific timeframes (<5 seconds, within 1 second) and percentages (100%)
+- [x] Success criteria are technology-agnostic (no implementation details)
+  - **Status**: PASS - No mention of specific frameworks, languages, or tools
+- [x] All acceptance scenarios are defined
+  - **Status**: PASS - 3 user stories with 3-5 scenarios each
+- [x] Edge cases are identified
+  - **Status**: PASS - 3 edge cases documented (DB failure, missing translations, multiple users)
+- [x] Scope is clearly bounded
+  - **Status**: PASS - Focused on TopNav language selector only
+- [x] Dependencies and assumptions identified
+  - **Status**: PASS - 5 assumptions documented about existing infrastructure
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+  - **Status**: PASS - Each FR linked to acceptance scenarios in user stories
+- [x] User scenarios cover primary flows
+  - **Status**: PASS - 3 stories cover: selecting language, default language, loading from DB
+- [x] Feature meets measurable outcomes defined in Success Criteria
+  - **Status**: PASS - All SC items have clear metrics
+- [x] No implementation details leak into specification
+  - **Status**: PASS - "i18n" mentioned only in assumptions about existing infrastructure
+
+## Validation Results
+
+**All checklist items PASS** - Specification is complete and ready for `/speckit.clarify` or `/speckit.plan`.
+
+### Summary
+- **Content Quality**: 4/4 items pass
+- **Requirement Completeness**: 8/8 items pass
+- **Feature Readiness**: 4/4 items pass
+
+**No [NEEDS CLARIFICATION] markers** - Specification can proceed directly to planning phase.
+
+## Notes
+
+- Specification has been validated and is ready for the next phase

--- a/specs/002-language-switcher/data-model.md
+++ b/specs/002-language-switcher/data-model.md
@@ -1,0 +1,132 @@
+# Data Model: Language Switching Feature
+
+## Entity: Language
+
+Represents a supported interface language in the application.
+
+### Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | INTEGER | Yes | Primary key, auto-increment |
+| `code` | TEXT | Yes | ISO language code (e.g., "vi", "en") |
+| `name` | TEXT | Yes | Display name in Vietnamese (e.g., "Tiếng Việt", "Tiếng Anh") |
+| `nameEn` | TEXT | No | Display name in English (e.g., "Vietnamese", "English") |
+
+### Validation Rules
+
+- `code` must be unique (enforced by UNIQUE constraint)
+- `code` must be 2-5 characters (ISO standard)
+- `name` must not be empty
+
+### State Transitions
+
+- Languages are read-only from database perspective
+- No lifecycle management needed (static data)
+
+---
+
+## Entity: UserPreference
+
+Represents user-specific settings stored in the database.
+
+### Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | INTEGER | Yes | Primary key, auto-increment |
+| `userId` | TEXT | Yes | Device/user identifier for local-first storage |
+| `preferenceKey` | TEXT | Yes | Key name (e.g., "language") |
+| `preferenceValue` | TEXT | Yes | Value (e.g., "vi") |
+| `createdAt` | TEXT | Yes | ISO timestamp of creation |
+| `updatedAt` | TEXT | Yes | ISO timestamp of last update |
+
+### Validation Rules
+
+- `userId` must not be empty
+- `preferenceKey` must not be empty
+- `preferenceValue` must not be empty
+- Unique constraint on `(userId, preferenceKey)` pair
+
+### State Transitions
+
+- **Create**: New preference record when user first selects language
+- **Update**: Modify `preferenceValue` and `updatedAt` when language changes
+- **Read**: Query by `userId` and `preferenceKey` to retrieve preference
+
+---
+
+## Relationships
+
+### One-to-Many: User to Preferences
+
+- One user (identified by `userId`) can have multiple preferences
+- Each preference has a unique `preferenceKey`
+- Language preference is one of many possible preferences
+
+---
+
+## Database Schema
+
+### Table: languages
+
+```sql
+CREATE TABLE IF NOT EXISTS languages (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  code TEXT UNIQUE NOT NULL,
+  name TEXT NOT NULL,
+  nameEn TEXT
+);
+```
+
+### Table: user_preferences
+
+```sql
+CREATE TABLE IF NOT EXISTS user_preferences (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  userId TEXT NOT NULL,
+  preferenceKey TEXT NOT NULL,
+  preferenceValue TEXT NOT NULL,
+  createdAt TEXT NOT NULL,
+  updatedAt TEXT NOT NULL,
+  UNIQUE(userId, preferenceKey)
+);
+```
+
+---
+
+## Data Flow
+
+### Loading Languages on Startup
+
+1. Application starts
+2. Renderer calls `window.api.getLanguages()`
+3. Main process queries `SELECT * FROM languages`
+4. Returns array of language objects to renderer
+5. Renderer stores in Pinia `languageStore.languages`
+
+### Loading Language Preference
+
+1. Application starts
+2. Renderer calls `window.api.getLanguagePreference(userId)`
+3. Main process queries `SELECT preferenceValue FROM user_preferences WHERE userId = ? AND preferenceKey = 'language'`
+4. If found: returns stored language code
+5. If not found: returns default "vi"
+6. Renderer stores in Pinia `languageStore.currentLanguage`
+
+### Setting Language Preference
+
+1. User selects language from dropdown
+2. Renderer calls `window.api.setLanguagePreference(userId, languageCode)`
+3. Main process upserts preference record (INSERT OR REPLACE)
+4. Returns success status to renderer
+5. Renderer updates Pinia store and triggers UI refresh
+
+---
+
+## Assumptions
+
+- Language data will be seeded during application initialization
+- Device/user identifier will be generated on first app launch
+- Existing database schema migration will handle new tables
+- No complex validation needed (language codes are standard ISO codes)

--- a/specs/002-language-switcher/plan.md
+++ b/specs/002-language-switcher/plan.md
@@ -1,0 +1,249 @@
+# Implementation Plan: Language Switching Feature
+
+**Branch**: `002-language-switcher` | **Date**: 2026-04-04 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/002-language-switcher/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/plan-template.md` for the execution workflow.
+
+## Summary
+
+Add a language selector combobox to the TopNav that allows users to switch between Vietnamese and English interfaces. The selector loads available languages from the database and persists user preferences using SQLite storage. Default language is Vietnamese, with graceful error handling for database failures.
+
+**Technical Approach**: 
+- Add `languages` and `user_preferences` tables to SQLite
+- Implement IPC handlers for language CRUD operations
+- Create Vue component for language selector
+- Use Pinia store for reactive state management
+- Follow existing Electron + Vue + TypeScript patterns
+
+---
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x, Vue 3.4+, Element Plus 2.x
+**Primary Dependencies**: Pinia (state), better-sqlite3 (database), Electron 27+
+**Storage**: SQLite via better-sqlite3 (local-first, stored in userData directory)
+**Testing**: Manual testing + future Vitest integration
+**Target Platform**: Desktop application (Windows, macOS, Linux via Electron)
+**Project Type**: desktop-app (Electron + Vue + SQLite)
+**Performance Goals**: Language switch completes within 1 second, UI updates immediately
+**Constraints**: Offline-capable, local-first storage, TypeScript type safety required
+**Scale/Scope**: Single-user desktop application, 2-5 languages supported
+
+---
+
+## Constitution Check
+
+### Gate 1: Local-First Architecture (NON-NEGOTIABLE)
+
+✅ **PASS**: All data stored locally in SQLite database
+- Languages table: static data seeded on init
+- User preferences: stored in user_preferences table
+- No cloud sync required for core functionality
+
+### Gate 2: Type-Safe Development (NON-NEGOTIABLE)
+
+✅ **PASS**: All code written in TypeScript
+- Language entity has TypeScript interface
+- IPC handlers have proper type definitions
+- Pinia store uses typed state and actions
+
+### Gate 3: Data Integrity & Validation
+
+✅ **PASS**: Multi-layer validation
+- Client-side: Vue component validation
+- Database: UNIQUE constraints on language code and preference pairs
+- Schema: Proper field types and constraints
+
+### Gate 4: Component-Based UI Architecture
+
+✅ **PASS**: Vue 3 Composition API + Pinia
+- LanguageSelector component with scoped styles
+- Pinia store for language state management
+- Element Plus components for UI
+
+### Gate 5: Offline-First User Experience
+
+✅ **PASS**: Fully functional offline
+- Language data stored locally in SQLite
+- Fallback to hardcoded languages on DB failure
+- No network connectivity required
+
+**All gates passed** - No violations to justify
+
+---
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/002-language-switcher/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output - technology decisions
+├── data-model.md        # Phase 1 output - entities and schema
+├── quickstart.md        # Phase 1 output - implementation guide
+├── checklists/
+│   └── requirements.md  # Specification quality checklist
+└── spec.md              # Feature specification
+```
+
+### Source Code Structure (Electron + Vue App)
+
+```text
+src/
+├── main/
+│   ├── index.ts              # IPC handlers for language operations
+│   └── database.ts           # SQLite CRUD for languages, user_preferences
+├── preload/
+│   └── index.ts              # Expose language APIs to renderer
+└── renderer/
+    └── src/
+        ├── stores/
+        │   └── language.ts   # Pinia store for language state
+        ├── components/
+        │   └── LanguageSelector.vue  # Language dropdown component
+        ├── layouts/
+        │   └── TopNav.vue    # Updated with language selector
+        ├── types/
+        │   └── language.ts   # TypeScript interfaces
+        └── locales/
+            ├── vi.json       # Vietnamese translations (existing)
+            └── en.json       # English translations (existing)
+```
+
+**Structure Decision**: This is an Electron desktop application with Vue frontend. The feature adds to the existing structure without changing the overall architecture. IPC handlers go in main process, UI components in renderer, and state management in Pinia stores.
+
+---
+
+## Implementation Phases
+
+### Phase 0: Research & Decisions (Complete)
+
+**Research completed in [research.md](research.md)**:
+- Database schema design for language preferences
+- IPC communication patterns
+- Vue component structure
+- Pinia store implementation
+- Error handling strategy
+- Default language behavior
+
+**Key Decisions**:
+1. Add `languages` and `user_preferences` tables to SQLite
+2. Use existing IPC pattern from database.ts
+3. Create reusable LanguageSelector component
+4. Use Pinia for reactive state management
+5. Graceful fallback on database errors
+
+### Phase 1: Design & Contracts
+
+#### Data Model (Complete)
+
+See [data-model.md](data-model.md) for full details:
+
+**Entities**:
+- `Language`: id, code, name, nameEn
+- `UserPreference`: id, userId, preferenceKey, preferenceValue, createdAt, updatedAt
+
+**Database Schema**:
+- `languages` table with UNIQUE constraint on code
+- `user_preferences` table with UNIQUE constraint on (userId, preferenceKey)
+
+#### Interface Contracts
+
+**IPC Contracts** (main ↔ renderer):
+
+1. `getLanguages()` → `Language[]`
+   - Returns all available languages from database
+   
+2. `getLanguagePreference(userId: string)` → `string`
+   - Returns user's selected language code (or "vi" default)
+   
+3. `setLanguagePreference(userId: string, language: string)` → `boolean`
+   - Saves user's language selection
+   - Returns success status
+
+**UI Contracts** (component ↔ store):
+
+1. LanguageSelector emits `language-changed` event
+2. Pinia store provides reactive `currentLanguage` state
+3. TopNav component calls `loadLanguages()` on mount
+
+#### Quickstart Guide
+
+See [quickstart.md](quickstart.md) for implementation steps:
+1. Database migration
+2. Main process IPC handlers
+3. Preload script update
+4. Pinia store creation
+5. LanguageSelector component
+6. TopNav integration
+7. Testing checklist
+
+### Phase 2: Task Generation (Deferred)
+
+**Not created by /speckit.plan** - Use `/speckit.tasks` command to generate detailed tasks.
+
+---
+
+## Complexity Tracking
+
+No violations detected in Constitution Check. All requirements align with existing patterns and constraints.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|--------------------------------------|
+| N/A | N/A | N/A |
+
+---
+
+## Implementation Checklist
+
+### Database Layer
+- [ ] Add `languages` table to database schema
+- [ ] Add `user_preferences` table to database schema
+- [ ] Seed initial language data (vi, en)
+- [ ] Implement CRUD operations in database.ts
+
+### Main Process (Electron)
+- [ ] Add `getLanguages` IPC handler
+- [ ] Add `getLanguagePreference` IPC handler
+- [ ] Add `setLanguagePreference` IPC handler
+- [ ] Register handlers in main/index.ts
+
+### Preload Script
+- [ ] Expose language APIs via contextBridge
+- [ ] Add TypeScript type definitions
+
+### Renderer (Vue)
+- [ ] Create Pinia language store
+- [ ] Create LanguageSelector component
+- [ ] Update TopNav to include selector
+- [ ] Connect to i18n system
+
+### Testing
+- [ ] Manual UI testing
+- [ ] TypeScript type checking
+- [ ] ESLint validation
+- [ ] Code formatting with Prettier
+
+---
+
+## Risk Assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Database migration fails | Low | Medium | Use transactions, provide rollback script |
+| Type safety violations | Low | High | Run `npm run typecheck` before commit |
+| UI not updating reactively | Medium | Medium | Use Pinia computed properties, test reactivity |
+| Default language not working | Low | High | Test fresh install scenario |
+| Error handling gaps | Medium | Medium | Comprehensive edge case testing |
+
+---
+
+## Next Steps
+
+1. **Immediate**: Review this plan and confirm approach
+2. **Then**: Use `/speckit.tasks` to generate detailed implementation tasks
+3. **Implementation**: Follow quickstart.md guide
+4. **Testing**: Execute test checklist
+5. **Review**: Run typecheck, lint, and format before commit

--- a/specs/002-language-switcher/quickstart.md
+++ b/specs/002-language-switcher/quickstart.md
@@ -1,0 +1,109 @@
+# Quickstart: Language Switching Feature
+
+## Prerequisites
+
+- Existing Sora Piggy application with Vue 3 + TypeScript setup
+- SQLite database with existing tables (transactions, categories, accounts)
+- Electron application structure with main process and renderer
+
+## Implementation Steps
+
+### Step 1: Database Migration
+
+Add new tables to the SQLite database:
+
+1. Open `src/main/database.ts`
+2. Add table creation for `languages` and `user_preferences`
+3. Seed initial language data (Vietnamese and English)
+
+### Step 2: Main Process IPC Handlers
+
+Add IPC handlers in `src/main/index.ts`:
+
+1. `getLanguages()` - Returns all available languages
+2. `getLanguagePreference(userId)` - Returns user's language preference
+3. `setLanguagePreference(userId, languageCode)` - Saves user's language selection
+
+### Step 3: Preload Script Update
+
+Expose new APIs in `src/preload/index.ts`:
+
+```typescript
+contextBridge.exposeInMainWorld('api', {
+  getLanguages: () => ipcRenderer.invoke('db:getLanguages'),
+  getLanguagePreference: (userId: string) => ipcRenderer.invoke('db:getLanguagePreference', userId),
+  setLanguagePreference: (userId: string, language: string) => ipcRenderer.invoke('db:setLanguagePreference', userId, language)
+})
+```
+
+### Step 4: Pinia Store
+
+Create or extend `src/renderer/src/stores/language.ts`:
+
+```typescript
+import { defineStore } from 'pinia'
+
+export const useLanguageStore = defineStore('language', {
+  state: () => ({
+    languages: [] as Language[],
+    currentLanguage: 'vi' as string,
+    isLoading: false
+  }),
+  actions: {
+    async loadLanguages() { /* ... */ },
+    async loadPreference() { /* ... */ },
+    async setLanguage(code: string) { /* ... */ }
+  }
+})
+```
+
+### Step 5: Language Selector Component
+
+Create `src/renderer/src/components/LanguageSelector.vue`:
+
+- Use Element Plus `el-select` component
+- Populate options from `languageStore.languages`
+- Emit change event on selection
+- Position in TopNav (top-right corner)
+
+### Step 6: Integration with TopNav
+
+Update `src/renderer/src/layouts/TopNav.vue`:
+
+1. Import LanguageSelector component
+2. Import languageStore
+3. Position selector in top-right area
+4. Call `languageStore.loadLanguages()` on mount
+5. Call `languageStore.loadPreference()` on mount
+
+### Step 7: Default Language Fallback
+
+Implement graceful error handling:
+
+1. Wrap database calls in try-catch
+2. On failure, use hardcoded fallback languages
+3. Log errors to console for debugging
+4. Display default Vietnamese interface
+
+## Testing Checklist
+
+- [ ] Language selector appears in TopNav
+- [ ] Clicking selector shows available languages
+- [ ] Selecting a language updates interface immediately
+- [ ] Language preference persists after app restart
+- [ ] Default to Vietnamese on fresh install
+- [ ] Graceful fallback when database is unavailable
+- [ ] TypeScript type checking passes
+- [ ] ESLint passes with no errors
+- [ ] Code formatting with Prettier
+
+## Rollback Plan
+
+If issues arise:
+
+1. Revert database migration (drop new tables)
+2. Remove IPC handlers from main process
+3. Remove preload script additions
+4. Remove Pinia store
+5. Remove LanguageSelector component
+6. Revert TopNav modifications

--- a/specs/002-language-switcher/research.md
+++ b/specs/002-language-switcher/research.md
@@ -1,0 +1,111 @@
+# Research: Language Switching Feature
+
+## Decision 1: Database Schema for Language Preferences
+
+**Decision**: Add a `user_preferences` table to store language settings with user/device identifier
+
+**Rationale**: 
+- Aligns with local-first architecture (Constitution §I)
+- Uses existing SQLite infrastructure
+- Allows per-user preference isolation on shared machines
+- Non-sensitive data (language code only) doesn't require encryption
+
+**Alternatives considered**:
+- Store in localStorage: Not consistent with SQLite-based local-first approach
+- Store in existing transactions table: Would violate single-responsibility principle
+- Hardcode in config file: Not flexible for dynamic language list
+
+---
+
+## Decision 2: IPC Communication Pattern for Language Selection
+
+**Decision**: Use existing IPC pattern from database.ts with new handlers
+
+**Rationale**:
+- Follows established pattern in codebase (Constitution §Development Workflow)
+- Maintains type safety through TypeScript interfaces
+- Keeps main process handling database operations
+- Renderer remains reactive via Pinia store
+
+**Implementation approach**:
+- Add `getLanguages()` IPC handler
+- Add `getLanguagePreference()` IPC handler
+- Add `setLanguagePreference()` IPC handler
+- Use existing database.ts CRUD patterns
+
+---
+
+## Decision 3: Vue Component for Language Selector
+
+**Decision**: Create reusable `LanguageSelector` component in TopNav
+
+**Rationale**:
+- Follows component-based architecture (Constitution §IV)
+- Allows for potential reuse in other parts of UI
+- Maintains separation of concerns
+- Element Plus Select component fits requirements
+
+**Structure**:
+- Component in `src/renderer/src/components/LanguageSelector.vue`
+- Uses Element Plus `el-select` with `el-option`
+- Connected to Pinia store for state management
+- Emits change event for immediate UI update
+
+---
+
+## Decision 4: Pinia Store for Language State
+
+**Decision**: Create or extend existing Pinia store for language preferences
+
+**Rationale**:
+- Centralizes language state management (Constitution §IV)
+- Enables reactive updates across components
+- Separates UI state from database operations
+- Follows existing Pinia patterns in codebase
+
+**Store structure**:
+- `languageStore` with:
+  - `languages`: array of available languages
+  - `currentLanguage`: currently selected language
+  - `isLoading`: loading state indicator
+  - Actions: `loadLanguages()`, `setLanguage()`, `loadPreference()`
+
+---
+
+## Decision 5: Error Handling Strategy
+
+**Decision**: Graceful fallback with subtle error indicator
+
+**Rationale**:
+- Ensures app remains usable even if database fails
+- User is informed without being blocked
+- Aligns with offline-first user experience (Constitution §V)
+- Non-intrusive error reporting
+
+**Implementation**:
+- Try-catch around database operations
+- Fallback to hardcoded Vietnamese/English list
+- Console log for debugging
+- Optional tooltip for user awareness
+
+---
+
+## Decision 6: Default Language Behavior
+
+**Decision**: Vietnamese (vi) as default when no preference exists
+
+**Rationale**:
+- Matches original feature requirement
+- Appropriate for Vietnamese user base
+- Consistent with localization setup already in app
+
+---
+
+## Technology Stack Confirmed
+
+- **Language**: TypeScript (Constitution §II - NON-NEGOTIABLE)
+- **UI Framework**: Vue 3 + Composition API + Element Plus
+- **State Management**: Pinia stores
+- **Database**: SQLite via better-sqlite3 (local-first)
+- **Styling**: SCSS with CSS variables
+- **IPC**: Electron contextBridge pattern

--- a/specs/002-language-switcher/spec.md
+++ b/specs/002-language-switcher/spec.md
@@ -1,0 +1,116 @@
+# Feature Specification: Language Switching Feature
+
+**Feature Branch**: `002-language-switcher`
+**Created**: 2026-04-04
+**Status**: Draft
+**Input**: User description: "Bổ sung chức năng chuyển đổi ngôn ngữ cho app
+Hiện trạng:
+- Hiện tại app đã hỗ trợ nhiều ngôn ngữ (vi và en) nhưng chưa có chức năng để chuyển đổi ngôn ngữ
+Yêu cầu:
+- Bổ sung chức năng chuyển đổi ngôn ngữ cho app, cụ thể:
++ Mặc định ngôn ngữ vi
++ Combobox chọn ngôn ngữ là trên TopNav, góc phải trên cùng
++ Combobox có danh sách ngôn ngữ nên được load từ database"
+
+## User Scenarios & Testing
+
+### User Story 1 - Select Language from TopNav (Priority: P1)
+
+User opens the application and wants to change the interface language. They locate the language selector in the TopNav area at the top right corner of the screen and select their preferred language from the dropdown menu.
+
+**Why this priority**: This is the core functionality of the feature - without the ability to select and switch languages, the entire feature fails to deliver value.
+
+**Independent Test**: Can be fully tested by navigating to the TopNav and interacting with the language selector, then verifying the interface language changes accordingly.
+
+**Acceptance Scenarios**:
+
+1. **Given** the application is open, **When** the user clicks on the language selector in the TopNav, **Then** a list of available languages is displayed
+2. **Given** the language selector is open, **When** the user selects a different language from the list, **Then** the application interface immediately updates to display text in the selected language
+3. **Given** the user has selected a language, **When** they close and reopen the application, **Then** the selected language persists and the interface displays in that language
+
+---
+
+### User Story 2 - Default Vietnamese Language (Priority: P2)
+
+When a new user first opens the application or when the application has no previously saved language preference, the interface displays in Vietnamese by default.
+
+**Why this priority**: Ensures new users have an immediate, familiar experience without needing to configure settings.
+
+**Independent Test**: Can be tested by clearing any saved language preferences and launching the application to verify Vietnamese is displayed.
+
+**Acceptance Scenarios**:
+
+1. **Given** no language preference has been saved, **When** the application starts, **Then** all interface text displays in Vietnamese
+2. **Given** the application was previously configured with a different language, **When** the user clears their preferences, **Then** the next startup defaults to Vietnamese
+
+---
+
+### User Story 3 - Language List from Database (Priority: P3)
+
+The available languages shown in the selector are loaded dynamically from the application's database, allowing for flexible management of supported languages.
+
+**Why this priority**: Provides maintainability and future-proofing by decoupling language configuration from code.
+
+**Independent Test**: Can be verified by checking that the language list in the selector matches what is stored in the database.
+
+**Acceptance Scenarios**:
+
+1. **Given** the database contains language records, **When** the application starts, **Then** the language selector displays all available languages from the database
+2. **Given** a new language is added to the database, **When** the application restarts, **Then** the new language appears in the selector
+3. **Given** a language is removed from the database, **When** the application restarts, **Then** the removed language no longer appears in the selector
+
+---
+
+### Edge Cases
+
+- What happens when the database connection fails or is unavailable? The application should gracefully fall back to a hardcoded default language list (Vietnamese and English), displaying default Vietnamese with a subtle error indicator (tooltip or console log) to inform the user without blocking app usage.
+- How does the system handle missing translation strings for a selected language? The system should display the key or a fallback text rather than crashing or showing empty strings.
+- What occurs when multiple users on the same machine have different language preferences? Each user's preference should be stored and restored independently.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: System MUST display a language selector combobox in the TopNav area of the application interface
+- **FR-002**: System MUST load the list of available languages from the database rather than hardcoding them
+- **FR-003**: System MUST default to Vietnamese (vi) when no language preference is saved
+- **FR-004**: Users MUST be able to select a different language from the selector and see the interface update immediately
+- **FR-005**: System MUST persist the selected language preference in SQLite database as a user preference record
+- **FR-006**: System MUST handle missing database gracefully by falling back to a default language list with default Vietnamese and subtle error indicator
+
+### Key Entities
+
+- **Language**: Represents a supported interface language with attributes: language code (e.g., "vi", "en"), display name (e.g., "Tiếng Việt", "English")
+- **Language Preference**: Represents a user's selected language setting, stored as a preference value in SQLite database, linked to user/device identifier for local-first storage
+
+### Out of Scope
+
+- Translation content management (adding, editing, or deleting translation strings) is not included in this feature
+- The scope is limited to language selection UI and preference persistence only
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: Users can successfully change the interface language in under 5 seconds through the TopNav selector
+- **SC-002**: Language changes are reflected in the UI immediately (within 1 second) after selection
+- **SC-003**: The language preference persists correctly across 100% of application restarts
+- **SC-004**: 100% of supported languages (Vietnamese and English) are available in the selector when database is accessible
+
+## Assumptions
+
+- The application already has existing localization infrastructure (i18n) for Vietnamese and English translations
+- The database schema already supports or will support a languages table with necessary attributes
+- The TopNav component has sufficient space and positioning to accommodate the language selector
+- Users have the appropriate permissions to change application language settings
+- The feature will use existing application preferences system to store language selection
+- Language preferences are non-sensitive data and stored using simple device identifier for local-first approach
+
+## Clarifications
+
+### Session 2026-04-04
+
+- Q: Where should the language preference be stored and is it user-specific or system-wide? → A: Store in SQLite database as a user preference record
+- Q: Should language preferences be stored with user identification, and what privacy considerations apply? → A: Store with simple user/device identifier (local-first approach, non-sensitive)
+- Q: How should the application behave if there's an error loading languages from the database on startup? → A: Show default Vietnamese with subtle error indicator
+- Q: Which items should be explicitly declared as out of scope for this feature? → A: Translation content management is out of scope

--- a/specs/002-language-switcher/tasks.md
+++ b/specs/002-language-switcher/tasks.md
@@ -1,0 +1,274 @@
+---
+description: 'Task list for language switching feature implementation'
+---
+
+# Tasks: Language Switching Feature
+
+**Input**: Design documents from `/specs/002-language-switcher/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md
+
+**Tests**: Tests are OPTIONAL - not explicitly requested in feature specification
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **Electron + Vue App**: `src/main/`, `src/preload/`, `src/renderer/src/`
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Project initialization and basic structure
+
+- [ ] T001 [P] Review implementation plan and confirm approach with team
+- [ ] T002 [P] Set up development environment (ensure npm packages installed)
+- [ ] T003 [P] Verify existing i18n setup for Vietnamese and English translations
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core infrastructure that MUST be complete before ANY user story can be implemented
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+### Database Layer
+
+- [x] T004 Add `languages` table schema to `src/main/database.ts`
+  - Fields: id, code (UNIQUE), name, nameEn
+  - Create table on app initialization
+
+- [x] T005 Add `user_preferences` table schema to `src/main/database.ts`
+  - Fields: id, userId, preferenceKey, preferenceValue, createdAt, updatedAt
+  - UNIQUE constraint on (userId, preferenceKey)
+
+- [x] T006 [P] Seed initial language data in database initialization
+  - Insert Vietnamese (vi) and English (en) records
+
+### Main Process IPC Handlers
+
+- [x] T007 Add `getLanguages()` IPC handler in `src/main/index.ts`
+  - Returns array of Language objects from database
+
+- [x] T008 Add `getLanguagePreference(userId)` IPC handler in `src/main/index.ts`
+  - Returns user's language preference or "vi" default
+
+- [x] T009 Add `setLanguagePreference(userId, language)` IPC handler in `src/main/index.ts`
+  - Upserts preference record with current timestamp
+
+### Preload Script
+
+- [x] T010 Expose language APIs in `src/preload/index.ts`
+  - Add `getLanguages()`, `getLanguagePreference()`, `setLanguagePreference()` methods
+  - Add TypeScript type definitions for all methods
+
+**Checkpoint**: Foundation ready - user story implementation can now begin in parallel
+
+---
+
+## Phase 3: User Story 1 - Select Language from TopNav (Priority: P1) 🎯 MVP
+
+**Goal**: User can open language selector in TopNav, see available languages, and switch interface language
+
+**Independent Test**: Navigate to TopNav, click language selector, select different language, verify interface updates immediately
+
+### Implementation for User Story 1
+
+- [x] T011 [P] [US1] Create TypeScript interface for Language in `src/renderer/src/types/language.ts`
+  - Define Language interface with code, name, nameEn properties
+
+- [x] T012 [P] [US1] Create Pinia language store in `src/renderer/src/stores/language.ts`
+  - State: languages array, currentLanguage string, isLoading boolean
+  - Actions: loadLanguages(), loadPreference(), setLanguage()
+
+- [x] T013 [P] [US1] Create LanguageSelector component in `src/renderer/src/components/LanguageSelector.vue`
+  - Use Element Plus `el-select` component
+  - Populate options from languageStore.languages
+  - Emit `language-changed` event on selection
+  - Position: top-right corner of TopNav
+
+- [x] T014 [US1] Update TopNav layout in `src/renderer/src/layouts/TopNav.vue`
+  - Import LanguageSelector component
+  - Import languageStore
+  - Position selector in top-right area
+  - Call `languageStore.loadLanguages()` on mount
+  - Call `languageStore.loadPreference()` on mount
+
+- [x] T015 [US1] Connect language store to i18n system
+  - Update i18n locale when language changes
+  - Ensure UI text updates reactively
+
+**Checkpoint**: At this point, User Story 1 should be fully functional and testable independently
+
+---
+
+## Phase 4: User Story 2 - Default Vietnamese Language (Priority: P2)
+
+**Goal**: Application displays Vietnamese by default when no language preference is saved
+
+**Independent Test**: Clear language preferences, restart app, verify Vietnamese interface displays
+
+### Implementation for User Story 2
+
+- [x] T016 [US2] Implement default language fallback in language store
+  - Return "vi" when no preference found in database
+  - Store default in Pinia state
+
+- [x] T017 [US2] Update TopNav to handle default language on fresh install
+  - Ensure language selector shows Vietnamese as default selection
+
+- [ ] T018 [US2] Test default language behavior
+  - Verify Vietnamese displays on first app launch
+  - Verify Vietnamese displays after clearing preferences
+
+**Checkpoint**: At this point, User Stories 1 AND 2 should both work independently
+
+---
+
+## Phase 5: User Story 3 - Language List from Database (Priority: P3)
+
+**Goal**: Language selector loads available languages from database, not hardcoded
+
+**Independent Test**: Verify language list matches database records, add/remove language in DB and verify selector updates
+
+### Implementation for User Story 3
+
+- [x] T019 [P] [US3] Implement database query for getLanguages() in `src/main/database.ts`
+  - Query: `SELECT * FROM languages ORDER BY code`
+  - Return array of language objects
+
+- [x] T020 [P] [US3] Add database initialization logic to create tables on first run
+  - Check if tables exist, create if not
+  - Seed language data if empty
+
+- [ ] T021 [US3] Test language list from database
+  - Verify selector shows languages from DB
+  - Add new language record to DB, restart app, verify it appears
+  - Remove language record from DB, restart app, verify it disappears
+
+**Checkpoint**: All user stories should now be independently functional
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Improvements that affect multiple user stories
+
+- [x] T022 [P] Add error handling for database failures
+  - Wrap database calls in try-catch
+  - Fallback to hardcoded Vietnamese/English list
+  - Log errors to console for debugging
+
+- [x] T023 [P] Add graceful error indicator for database issues
+  - Subtle tooltip or console log when DB unavailable
+  - Ensure app remains usable with default language
+
+- [x] T024 [P] Run TypeScript type checking
+  - Execute `npm run typecheck` to verify types
+
+- [x] T025 [P] Run ESLint validation
+  - Execute `npm run lint` to verify code style
+
+- [x] T026 [P] Run Prettier formatting
+  - Execute `npm run format` to format code
+
+- [x] T027 [P] Update documentation
+  - Add any new constants or types to appropriate files
+  - Document any configuration changes
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion - BLOCKS all user stories
+- **User Stories (Phase 3-5)**: All depend on Foundational phase completion
+  - User stories can proceed in parallel (if staffed)
+  - Or sequentially in priority order (P1 → P2 → P3)
+- **Polish (Phase 6)**: Depends on all desired user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Can start after Foundational (Phase 2) - No dependencies on other stories
+- **User Story 2 (P2)**: Can start after Foundational (Phase 2) - Builds on User Story 1
+- **User Story 3 (P3)**: Can start after Foundational (Phase 2) - Independent functionality
+
+### Within Each User Story
+
+- Models before services
+- Services before endpoints
+- Core implementation before integration
+- Story complete before moving to next priority
+
+### Parallel Opportunities
+
+- All Setup tasks marked [P] can run in parallel
+- All Foundational tasks marked [P] can run in parallel (within Phase 2)
+- Once Foundational phase completes, all user stories can start in parallel (if team capacity allows)
+- All tests for a user story marked [P] can run in parallel
+- Different user stories can be worked on in parallel by different team members
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Launch all models for User Story 1 together:
+Task: "Create Language interface in src/renderer/src/types/language.ts"
+Task: "Create Pinia language store in src/renderer/src/stores/language.ts"
+
+# Launch component and layout together:
+Task: "Create LanguageSelector component in src/renderer/src/components/LanguageSelector.vue"
+Task: "Update TopNav layout in src/renderer/src/layouts/TopNav.vue"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational (CRITICAL - blocks all stories)
+3. Complete Phase 3: User Story 1
+4. **STOP and VALIDATE**: Test User Story 1 independently
+5. Deploy/demo if ready
+
+### Incremental Delivery
+
+1. Complete Setup + Foundational → Foundation ready
+2. Add User Story 1 → Test independently → Deploy/Demo (MVP!)
+3. Add User Story 2 → Test independently → Deploy/Demo
+4. Add User Story 3 → Test independently → Deploy/Demo
+5. Each story adds value without breaking previous stories
+
+### Parallel Team Strategy
+
+With multiple developers:
+
+1. Team completes Setup + Foundational together
+2. Once Foundational is done:
+   - Developer A: User Story 1 (language selector UI)
+   - Developer B: User Story 2 (default language)
+   - Developer C: User Story 3 (database integration)
+3. Stories complete and integrate independently
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Each user story should be independently completable and testable
+- Commit after each task or logical group
+- Stop at any checkpoint to validate story independently
+- Avoid: vague tasks, same file conflicts, cross-story dependencies that break independence

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -33,7 +33,7 @@ export const initDb = (): Database.Database => {
       amount INTEGER NOT NULL,
       time TEXT NOT NULL
     );
-    
+
     CREATE TABLE IF NOT EXISTS categories (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       name TEXT NOT NULL UNIQUE,
@@ -41,14 +41,43 @@ export const initDb = (): Database.Database => {
       icon TEXT,
       color TEXT
     );
-    
+
     CREATE TABLE IF NOT EXISTS accounts (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       name TEXT NOT NULL UNIQUE,
       type TEXT NOT NULL,
       balance INTEGER DEFAULT 0
     );
+
+    CREATE TABLE IF NOT EXISTS languages (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      code TEXT UNIQUE NOT NULL,
+      name TEXT NOT NULL,
+      nameEn TEXT
+    );
+
+    CREATE TABLE IF NOT EXISTS user_preferences (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      userId TEXT NOT NULL,
+      preferenceKey TEXT NOT NULL,
+      preferenceValue TEXT NOT NULL,
+      createdAt TEXT NOT NULL,
+      updatedAt TEXT NOT NULL,
+      UNIQUE(userId, preferenceKey)
+    );
   `);
+
+  // Seed initial language data if empty
+  const languageCount = db.prepare('SELECT COUNT(*) as count FROM languages').get() as {
+    count: number;
+  };
+  if (languageCount.count === 0) {
+    const insertLanguage = db.prepare(
+      'INSERT INTO languages (code, name, nameEn) VALUES (@code, @name, @nameEn)'
+    );
+    insertLanguage.run({ code: 'vi', name: 'Tiếng Việt', nameEn: 'Vietnamese' });
+    insertLanguage.run({ code: 'en', name: 'English', nameEn: 'English' });
+  }
 
   return db;
 };
@@ -192,6 +221,45 @@ export const updateAccount = (
 export const deleteAccount = (id: number): Database.RunResult => {
   if (!db) initDb();
   return db!.prepare('DELETE FROM accounts WHERE id = ?').run(id);
+};
+
+// CRUD operations for languages
+export const getLanguages = (): unknown[] => {
+  if (!db) initDb();
+  return db!.prepare('SELECT * FROM languages ORDER BY code').all();
+};
+
+export const getLanguageByCode = (code: string): unknown => {
+  if (!db) initDb();
+  return db!.prepare('SELECT * FROM languages WHERE code = ?').get(code);
+};
+
+// CRUD operations for user preferences
+export const getUserPreference = (userId: string, preferenceKey: string): string | null => {
+  if (!db) initDb();
+  const result = db!
+    .prepare('SELECT preferenceValue FROM user_preferences WHERE userId = ? AND preferenceKey = ?')
+    .get(userId, preferenceKey) as { preferenceValue: string } | undefined;
+  return result?.preferenceValue ?? null;
+};
+
+export const setUserPreference = (
+  userId: string,
+  preferenceKey: string,
+  preferenceValue: string
+): void => {
+  if (!db) initDb();
+  const now = new Date().toISOString();
+  const stmt = db!.prepare(
+    'INSERT OR REPLACE INTO user_preferences (userId, preferenceKey, preferenceValue, createdAt, updatedAt) VALUES (@userId, @preferenceKey, @preferenceValue, @createdAt, @updatedAt)'
+  );
+  stmt.run({
+    userId,
+    preferenceKey,
+    preferenceValue,
+    createdAt: now,
+    updatedAt: now
+  });
 };
 
 // Close database connection when app quits

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -19,6 +19,10 @@ import {
   createAccount,
   updateAccount,
   deleteAccount,
+  getLanguages,
+  getLanguageByCode,
+  getUserPreference,
+  setUserPreference,
   closeDatabase
 } from './database';
 
@@ -96,6 +100,15 @@ app.whenReady().then(() => {
   ipcMain.handle('db:createAccount', (_, account) => createAccount(account));
   ipcMain.handle('db:updateAccount', (_, id, account) => updateAccount(id, account));
   ipcMain.handle('db:deleteAccount', (_, id) => deleteAccount(id));
+
+  // Language handlers
+  ipcMain.handle('db:getLanguages', () => getLanguages());
+  ipcMain.handle('db:getLanguageByCode', (_, code) => getLanguageByCode(code));
+  ipcMain.handle('db:getLanguagePreference', (_, userId) => getUserPreference(userId, 'language'));
+  ipcMain.handle('db:setLanguagePreference', (_, userId, language) => {
+    setUserPreference(userId, 'language', language);
+    return true;
+  });
 
   createWindow();
 

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -18,6 +18,14 @@ interface Account {
   balance?: number;
 }
 
+// Language type definitions
+interface Language {
+  id: number;
+  code: string;
+  name: string;
+  nameEn?: string;
+}
+
 // API interface
 interface API {
   // Transaction APIs
@@ -60,6 +68,12 @@ interface API {
     }
   ) => Promise<void>;
   deleteAccount: (id: number) => Promise<void>;
+
+  // Language APIs
+  getLanguages: () => Promise<Language[]>;
+  getLanguageByCode: (code: string) => Promise<Language | undefined>;
+  getLanguagePreference: (userId: string) => Promise<string | null>;
+  setLanguagePreference: (userId: string, language: string) => Promise<boolean>;
 }
 
 declare global {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -56,7 +56,14 @@ const api = {
       balance?: number;
     }
   ) => ipcRenderer.invoke('db:updateAccount', id, account),
-  deleteAccount: (id: number) => ipcRenderer.invoke('db:deleteAccount', id)
+  deleteAccount: (id: number) => ipcRenderer.invoke('db:deleteAccount', id),
+
+  // Language APIs
+  getLanguages: () => ipcRenderer.invoke('db:getLanguages'),
+  getLanguageByCode: (code: string) => ipcRenderer.invoke('db:getLanguageByCode', code),
+  getLanguagePreference: (userId: string) => ipcRenderer.invoke('db:getLanguagePreference', userId),
+  setLanguagePreference: (userId: string, language: string) =>
+    ipcRenderer.invoke('db:setLanguagePreference', userId, language)
 };
 
 // Use `contextBridge` APIs to expose Electron APIs to

--- a/src/renderer/src/components/LanguageSelector.vue
+++ b/src/renderer/src/components/LanguageSelector.vue
@@ -1,0 +1,66 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { ElSelect, ElOption } from 'element-plus';
+import { useLanguageStore } from '@renderer/stores/language';
+
+const languageStore = useLanguageStore();
+
+const emit = defineEmits<{
+  'language-changed': [language: string];
+}>();
+
+const currentLanguage = computed({
+  get: () => languageStore.currentLanguage,
+  set: (value: string) => {
+    languageStore.setLanguage(value);
+    emit('language-changed', value);
+  }
+});
+
+const languages = computed(() => languageStore.languages);
+</script>
+
+<template>
+  <div class="language-selector">
+    <ElSelect
+      v-model="currentLanguage"
+      placeholder="Select language"
+      size="small"
+      class="language-select"
+      :disabled="languageStore.isLoading"
+    >
+      <ElOption v-for="lang in languages" :key="lang.code" :label="lang.name" :value="lang.code">
+        <span class="language-option">
+          <span class="language-name">{{ lang.name }}</span>
+          <span class="language-code">({{ lang.code }})</span>
+        </span>
+      </ElOption>
+    </ElSelect>
+  </div>
+</template>
+
+<style scoped lang="scss">
+.language-selector {
+  display: inline-block;
+}
+
+.language-select {
+  width: 120px;
+}
+
+.language-option {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.language-name {
+  font-weight: 500;
+}
+
+.language-code {
+  color: #909399;
+  font-size: 0.85em;
+  margin-left: 8px;
+}
+</style>

--- a/src/renderer/src/layouts/TopNav.vue
+++ b/src/renderer/src/layouts/TopNav.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, onMounted } from 'vue';
 import { ElButton } from 'element-plus';
 import { faPlus, faSave } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import LanguageSelector from '@renderer/components/LanguageSelector.vue';
+import { useLanguageStore } from '@renderer/stores/language';
 
 const emit = defineEmits<{
   addTransaction: [];
@@ -14,6 +16,7 @@ const props = defineProps<{
   mode?: 'list' | 'add';
 }>();
 
+const languageStore = useLanguageStore();
 const currentMode = computed(() => props.mode || 'list');
 
 const handlePrimaryAction = (): void => {
@@ -26,6 +29,11 @@ const handlePrimaryAction = (): void => {
 
 const buttonLabel = computed(() => (currentMode.value === 'add' ? 'Save' : 'Add Transaction'));
 const buttonIcon = computed(() => (currentMode.value === 'add' ? faSave : faPlus));
+
+onMounted(async () => {
+  await languageStore.loadLanguages();
+  await languageStore.loadPreference();
+});
 </script>
 
 <template>
@@ -34,6 +42,7 @@ const buttonIcon = computed(() => (currentMode.value === 'add' ? faSave : faPlus
       <h1 class="sora-page-title">{{ pageTitle }}</h1>
     </div>
     <div class="sora-right-section">
+      <LanguageSelector />
       <ElButton type="primary" size="small" @click="handlePrimaryAction">
         <template #icon>
           <FontAwesomeIcon :icon="buttonIcon" />

--- a/src/renderer/src/stores/language.ts
+++ b/src/renderer/src/stores/language.ts
@@ -1,0 +1,90 @@
+import { defineStore } from 'pinia';
+import { Language } from '@renderer/types/language';
+
+export const useLanguageStore = defineStore('language', {
+  state: () => ({
+    languages: [] as Language[],
+    currentLanguage: 'vi' as string,
+    isLoading: false,
+    error: null as string | null
+  }),
+
+  getters: {
+    currentLanguageObject: (state): Language | undefined => {
+      return state.languages.find((lang) => lang.code === state.currentLanguage);
+    },
+
+    availableLanguages: (state): Language[] => {
+      return state.languages;
+    }
+  },
+
+  actions: {
+    async loadLanguages() {
+      this.isLoading = true;
+      this.error = null;
+      try {
+        const response = await window.api.getLanguages();
+        this.languages = response as Language[];
+      } catch (err) {
+        console.error('Failed to load languages:', err);
+        this.error = 'Failed to load languages';
+        // Fallback to hardcoded languages
+        this.languages = [
+          { id: 1, code: 'vi', name: 'Tiếng Việt', nameEn: 'Vietnamese' },
+          { id: 2, code: 'en', name: 'English', nameEn: 'English' }
+        ];
+      } finally {
+        this.isLoading = false;
+      }
+    },
+
+    async loadPreference() {
+      this.isLoading = true;
+      this.error = null;
+      try {
+        // Generate a simple device/user identifier
+        // For local-first app, we can use a simple identifier
+        const userId = 'default-user';
+        const preference = await window.api.getLanguagePreference(userId);
+        if (preference) {
+          this.currentLanguage = preference;
+        } else {
+          // Default to Vietnamese
+          this.currentLanguage = 'vi';
+        }
+      } catch (err) {
+        console.error('Failed to load language preference:', err);
+        this.error = 'Failed to load language preference';
+        // Default to Vietnamese on error
+        this.currentLanguage = 'vi';
+      } finally {
+        this.isLoading = false;
+      }
+    },
+
+    async setLanguage(code: string) {
+      this.isLoading = true;
+      this.error = null;
+      try {
+        // Generate a simple device/user identifier
+        const userId = 'default-user';
+        await window.api.setLanguagePreference(userId, code);
+        this.currentLanguage = code;
+
+        // Update i18n locale
+        const i18n = (window as { $i18n?: { global: { locale: { value: string } } } }).$i18n;
+        if (i18n) {
+          i18n.global.locale.value = code;
+        }
+      } catch (err) {
+        console.error('Failed to set language preference:', err);
+        this.error = 'Failed to save language preference';
+        // Still update local state
+        this.currentLanguage = code;
+      } finally {
+        this.isLoading = false;
+      }
+    }
+  }
+});

--- a/src/renderer/src/types/language.ts
+++ b/src/renderer/src/types/language.ts
@@ -1,0 +1,6 @@
+export interface Language {
+  id: number;
+  code: string;
+  name: string;
+  nameEn?: string;
+}


### PR DESCRIPTION
- Add languages and user_preferences tables to SQLite database
- Seed initial Vietnamese and English language data
- Implement IPC handlers for language CRUD operations
- Create LanguageSelector Vue component in TopNav
- Add Pinia store for language state management
- Support default Vietnamese language on fresh install
- Include graceful error handling with fallback to hardcoded languages

Feature allows users to switch interface language via dropdown in TopNav. Language preferences persist in database and default to Vietnamese.