### PR TITLE
fix: transactions filters — show labels and defaults

### DIFF
--- a/src/renderer/src/components/ui-wrappers/SoraSelect.vue
+++ b/src/renderer/src/components/ui-wrappers/SoraSelect.vue
@@ -1,9 +1,10 @@
 <template>
   <a-select
     v-bind="attrs"
+    :value="props.modelValue"
     show-search
     :filter-option="false"
-    :search-value="props.modelValue"
+    :search-value="currentQuery"
     @search="onSearch"
     @change="handleChange"
     @popup-scroll="onPopupScroll"

--- a/src/renderer/src/views/transactions/SoraTransactionView.vue
+++ b/src/renderer/src/views/transactions/SoraTransactionView.vue
@@ -190,6 +190,11 @@ const onAccountSearch = (val: string): void => {
 onMounted(async () => {
   // Load transactions initially; categories/accounts are lazy-loaded on demand
   await fetchTransactions();
+
+  // Ensure default filter values: show 'Tất cả' for category/account and 'Mới nhất' for sort
+  selectedCategoryId.value = -1;
+  selectedAccountId.value = -1;
+  selectedSort.value = SORT_NEWEST;
 });
 
 // Watch for filter changes and refetch


### PR DESCRIPTION
Sửa SoraSelect để hiển thị label thay vì id và đặt default filters: category=-1 (Tất cả), account=-1 (Tất cả), sort=newest.