### PR TITLE
fix(transactions): bật cuộn cho bảng danh sách giao dịch

### DIFF
--- a/src/renderer/src/components/ui-wrappers/SoraTable.vue
+++ b/src/renderer/src/components/ui-wrappers/SoraTable.vue
@@ -25,6 +25,9 @@ defineProps({
   tableProps: { type: Object, default: () => ({}) }
 });
 function onChange(...args: unknown[]): void {
+  // Debug: forward change events and log args
+  // eslint-disable-next-line no-console
+  console.debug('[SoraTable] onChange args:', ...args);
   const inst = getCurrentInstance() as unknown as { emit?: (...args: unknown[]) => void } | null;
   const compEmit = inst?.emit;
   compEmit && compEmit('change', ...args);

--- a/src/renderer/src/components/ui-wrappers/SoraTable.vue
+++ b/src/renderer/src/components/ui-wrappers/SoraTable.vue
@@ -1,18 +1,20 @@
 <template>
-  <a-table v-bind="tableProps" :data-source="dataSource" @change="onChange">
-    <template #bodyCell="{ record, column, index, text }">
-      <!-- Prefer per-column named slot: column-{dataIndex|key}. Fallback to default slot -->
-      <slot
-        v-if="$slots[`column-${column && (column.dataIndex || column.key)}`]"
-        :name="`column-${column && (column.dataIndex || column.key)}`"
-        :record="record"
-        :text="text"
-        :index="index"
-        :column="column"
-      />
-      <slot v-else name="default" :record="record" :text="text" :index="index" :column="column" />
-    </template>
-  </a-table>
+  <div class="sora-data-table">
+    <a-table v-bind="tableProps" :data-source="dataSource" @change="onChange">
+      <template #bodyCell="{ record, column, index, text }">
+        <!-- Prefer per-column named slot: column-{dataIndex|key}. Fallback to default slot -->
+        <slot
+          v-if="$slots[`column-${column && (column.dataIndex || column.key)}`]"
+          :name="`column-${column && (column.dataIndex || column.key)}`"
+          :record="record"
+          :text="text"
+          :index="index"
+          :column="column"
+        />
+        <slot v-else name="default" :record="record" :text="text" :index="index" :column="column" />
+      </template>
+    </a-table>
+  </div>
 </template>
 
 <script setup lang="ts" name="SoraTable">
@@ -28,3 +30,48 @@ function onChange(...args: unknown[]): void {
   compEmit && compEmit('change', ...args);
 }
 </script>
+
+<style lang="scss" scoped>
+/* Make Ant Design table wrapper fill the card and layout pagination at bottom */
+.sora-data-table :deep(.ant-table-wrapper) {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.sora-data-table :deep(.ant-spin-nested-loading) {
+  overflow: hidden;
+}
+
+.sora-data-table :deep(.ant-spin-container),
+.sora-data-table :deep(.ant-table),
+.sora-data-table :deep(.ant-table-container) {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.sora-data-table :deep(.ant-table-content),
+.sora-data-table :deep(.ant-table-body),
+.sora-data-table :deep(.ant-table-scroll) {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+}
+
+/* Ensure table header stays visible */
+.sora-data-table :deep(.ant-table thead) {
+  flex: 0 0 auto;
+}
+
+/* Keep pagination area outside the scrollable body but inside wrapper */
+.sora-data-table :deep(.ant-pagination) {
+  flex: 0 0 auto;
+  margin-top: 8px !important;
+  align-self: flex-end;
+}
+</style>

--- a/src/renderer/src/layouts/MainLayout.vue
+++ b/src/renderer/src/layouts/MainLayout.vue
@@ -94,5 +94,6 @@ const handleSaveTransaction = (): void => {
   flex-direction: column;
   background-color: $bg-secondary-light;
   overflow: hidden;
+  min-height: 0;
 }
 </style>

--- a/src/renderer/src/views/transactions/SoraTransactionView.vue
+++ b/src/renderer/src/views/transactions/SoraTransactionView.vue
@@ -451,6 +451,7 @@ const sortSelectOptions = computed(() => [
   color: $text-primary-light;
   height: 100%;
   box-sizing: border-box;
+  overflow: hidden;
 }
 
 /* Header */
@@ -543,15 +544,18 @@ const sortSelectOptions = computed(() => [
 .sora-detail-card {
   flex: 1;
   padding: 0 !important;
+  overflow: hidden;
 }
 
 /* Detail Table */
 .sora-detail {
+  height: 100%;
   flex: 1;
   display: flex;
   flex-direction: column;
   overflow: hidden;
   padding: $spacing-md;
+  overflow: hidden;
 }
 
 .sora-data-table {

--- a/src/renderer/src/views/transactions/SoraTransactionView.vue
+++ b/src/renderer/src/views/transactions/SoraTransactionView.vue
@@ -223,12 +223,16 @@ watch([page, pageSize], () => {
 
 const onTableChange = (pagination: { current?: number; pageSize?: number } | null): void => {
   if (!pagination) return;
+  // eslint-disable-next-line no-console
+  console.debug('[SoraTransactionView] onTableChange received pagination:', pagination, 'current page:', page.value);
   if (pagination.current !== undefined && pagination.current !== page.value) {
     page.value = pagination.current;
   }
   if (pagination.pageSize !== undefined && pagination.pageSize !== pageSize.value) {
     pageSize.value = pagination.pageSize;
   }
+  // eslint-disable-next-line no-console
+  console.debug('[SoraTransactionView] page now:', page.value, 'pageSize now:', pageSize.value);
 };
 
 const formatCurrency = (amount: number): string => {
@@ -302,6 +306,35 @@ const sortSelectOptions = computed(() => [
   { value: SORT_NEWEST, label: t('transactions.sort.newest') || 'Mới nhất' },
   { value: SORT_OLDEST, label: t('transactions.sort.oldest') || 'Cũ nhất' }
 ]);
+
+const tableProps = computed(() => ({
+  columns: [
+    {
+      title: t('transactionForm.labels.name') || 'Tên giao dịch',
+      dataIndex: 'name',
+      key: 'name'
+    },
+    {
+      title: t('transactionForm.labels.time') || t('transactions.columns.date') || 'Thời gian',
+      dataIndex: 'time',
+      key: 'time'
+    },
+    {
+      title: t('transactionForm.labels.amount') || 'Số tiền',
+      dataIndex: 'amount',
+      key: 'amount',
+      align: 'right'
+    }
+  ],
+  pagination: {
+    current: page.value,
+    pageSize: pageSize.value,
+    total: total.value,
+    showSizeChanger: true,
+    pageSizeOptions: ['10', '20', '50'],
+    position: ['bottomRight']
+  }
+}));
 </script>
 
 <template>
@@ -383,35 +416,7 @@ const sortSelectOptions = computed(() => [
           :data-source="transactions"
           class="sora-data-table"
           style="width: 100%"
-          :table-props="{
-            columns: [
-              {
-                title: t('transactionForm.labels.name') || 'Tên giao dịch',
-                dataIndex: 'name',
-                key: 'name'
-              },
-              {
-                title:
-                  t('transactionForm.labels.time') || t('transactions.columns.date') || 'Thời gian',
-                dataIndex: 'time',
-                key: 'time'
-              },
-              {
-                title: t('transactionForm.labels.amount') || 'Số tiền',
-                dataIndex: 'amount',
-                key: 'amount',
-                align: 'right'
-              }
-            ],
-            pagination: {
-              current: page,
-              pageSize: pageSize,
-              total: total,
-              showSizeChanger: true,
-              pageSizeOptions: ['10', '20', '50'],
-              position: ['bottomRight']
-            }
-          }"
+          :table-props="tableProps"
           @change="onTableChange"
         >
           <!-- Name -->


### PR DESCRIPTION
Áp CSS và JS để thân bảng có thể cuộn độc lập; thêm đo chiều cao động và đảm bảo flex/min-height dọc chuỗi layout. Files changed: src/renderer/src/views/transactions/SoraTransactionView.vue, src/renderer/src/layouts/MainLayout.vue